### PR TITLE
Named args

### DIFF
--- a/beforeafterify.sh
+++ b/beforeafterify.sh
@@ -1,19 +1,27 @@
 #!/bin/bash
 
-convert before.png \
+while [[ "$#" > 1 ]]; do case $1 in
+    -b) before="$2";;
+    -a) after="$2";;
+    -o) output="$2";;
+    *) break;;
+  esac; shift; shift
+done
+
+convert ${before:-before.png} \
 	-colorspace sRGB \
 	-fill 'rgba(0,0,0,0.8)' -draw 'rectangle 10,10,100,42' \
 	-fill 'rgba(255,255,255, 0.7)' -font CourierNew -pointsize 20 -annotate +20+32 'Before' \
 	labelled-before.gif \
 
-convert after.png \
+convert ${after:-after.png} \
 	-colorspace sRGB \
 	-fill 'rgba(0,0,0,0.8)' -draw 'rectangle 10,10,90,42' \
 	-fill 'rgba(255,255,255, 0.7)' -font CourierNew -pointsize 20 -annotate +20+32 'After' \
 	labelled-after.gif \
 
-gifsicle --delay=150 --loop --colors 256 --merge labelled-before.gif labelled-after.gif -o beforeafter.gif \
+gifsicle --delay=150 --loop --colors 256 --merge labelled-before.gif labelled-after.gif -o ${output:-beforeafter}.gif \
 
 rm labelled-before.gif labelled-after.gif
 
-open beforeafter.gif -a safari
+open ${output:-beforeafter}.gif -a safari


### PR DESCRIPTION
Allow named args for before, after, and output. 

```
-b     Path to "before" image
-a     Path to "after" image
-o     File name for output image (e.g., "before-and-after")
```

Example:

```
beforeafterify -b screenshot-01.png -a screenshot-02.png -o before-and-after
```